### PR TITLE
The three input tags are actually "variables" that are pulled by the result set widget

### DIFF
--- a/client/scripts/widgets/ResultsListWidget.js
+++ b/client/scripts/widgets/ResultsListWidget.js
@@ -180,7 +180,11 @@ edu.rpi.tw.sesf.s2s.widgets.ResultsListWidget.prototype.update = function(data)
 		jQuery(config).children().each(function() {
 			if (parseInt(jQuery(this).val()) == self.limit) jQuery(this).attr("selected","selected");
 		});
-		jQuery(start).html("" + (this.offset + 1));
+		if(results == 0) {
+		    jQuery(start).html("" + this.offset);
+		} else {
+		    jQuery(start).html("" + (this.offset + 1));
+		}
 		jQuery(end).html("" + (this.offset + this.limit));
 		jQuery(total).html("" + results);
 		if ((this.offset + this.limit) >= results) {

--- a/opensearch/config.php
+++ b/opensearch/config.php
@@ -157,21 +157,29 @@ abstract class S2SConfig
 		if($this->setCacheControlHeader()) {
 			header($this->getSearchResultCacheControlHeader());
 		}
-				
+
 		$html = "";
-		if ($count > 0) {
-			$html .= "<div>";
-			$html .= "<input type='hidden' name='startIndex' value='$offset'/>";
-			$html .= "<input type='hidden' name='itemsPerPage' value='$limit'/>";
-			$html .= "<input type='hidden' name='totalResults' value='$count'/>";
-			$html .= "</div>";
-		}
-			
-		$html .= "<div class='result-list'>";
-		foreach($results as $i => $result) {
-			$html .= $this->getSearchResultOutput($result);
-		}
+		$html .= "<div>";
+		$html .= "<input type='hidden' name='startIndex' value='$offset'/>";
+		$html .= "<input type='hidden' name='itemsPerPage' value='$limit'/>";
+		$html .= "<input type='hidden' name='totalResults' value='$count'/>";
 		$html .= "</div>";
+			
+		if ($count > 0)
+        {
+		    $html .= "<div class='result-list'>";
+		    foreach($results as $i => $result) {
+			$html .= $this->getSearchResultOutput($result);
+		    }
+		    $html .= "</div>";
+		}
+        else
+        {
+		    $html .= "<div>";
+		    $html .= "<br/>";
+            $html .= "No results match your selections<br/>" ;
+		    $html .= "</div>";
+        }
 		return $html;
 	}
 	


### PR DESCRIPTION
The widget uses these to set the "offset-limt of total" display in the result set.
Even if the count is 0 these should be set or else we get 1-NaN of NaN
displayed. Now we get 1-0 of 0 and the arrows are not active.

Also, if there are no results then display a message letting the user
know. Even if the count is 0 there may still be an empty array returned.